### PR TITLE
Handle \% escaping in tt templating

### DIFF
--- a/src_build/tt.c
+++ b/src_build/tt.c
@@ -8,16 +8,16 @@
 #define NOB_STRIP_PREFIX
 #include "nob.h"
 
-void compile_c_code(String_View s) {
-    printf("%.*s\n", (int) s.count, s.data);
+void compile_c_code(String_View s, int newline) {
+    printf("%.*s%s", (int) s.count, s.data, (newline ? "\n" : ""));
 }
 
-void compile_byte_array(String_View s) {
+void compile_byte_array(String_View s, int newline) {
     printf("OUT(\"");
     for (uint64_t i = 0; i < s.count; ++i) {
         printf("\\x%02x", s.data[i]);
     }
-    printf("\", %lu);\n", s.count);
+    printf("\", %lu);%s", s.count, (newline ? "\n" : ""));
 }
 
 int main(int argc, char *argv[])
@@ -31,17 +31,42 @@ int main(int argc, char *argv[])
     if (!nob_read_entire_file(filepath, &sb)) return 1;
     String_View temp = sb_to_sv(sb);
     int c_code_mode = 0;
+    int escaped_match = 0;
+    int do_newline = 0;
     // TODO: Generate line control preprocessor directives
     // - GCC: https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html
     // - MSVC: https://learn.microsoft.com/en-us/cpp/preprocessor/hash-line-directive-c-cpp
     while (temp.count) {
         String_View token = sv_chop_by_delim(&temp, '%');
-        if (c_code_mode) {
-            compile_c_code(token);
-        } else {
-            compile_byte_array(token);
+
+        escaped_match = 0;
+        if (token.data[token.count-1] == '\\') { // Handle escaped percent sign
+            escaped_match = 1;
         }
-        c_code_mode = !c_code_mode;
+        do_newline = !escaped_match;
+        if (!escaped_match) {
+           if (c_code_mode) {
+                compile_c_code(token, do_newline);
+            } else {
+                compile_byte_array(token, do_newline);
+            }
+            c_code_mode = !c_code_mode;
+        } else { // We make sure to properly print the token
+            String_Builder sb = {0};
+            sb_append_buf(&sb, token.data, token.count-1);
+            if (c_code_mode) {
+                sb_append_cstr(&sb, "%");
+            } else {
+                sb_append_cstr(&sb, "%%");
+            }
+            String_View sv = sb_to_sv(sb);
+            if (c_code_mode) {
+                compile_c_code(sv, do_newline);
+            } else {
+                compile_byte_array(sv, do_newline);
+            }
+            sb_free(sb);
+        }
     }
 
     return 0;

--- a/src_build/tt.c
+++ b/src_build/tt.c
@@ -33,6 +33,8 @@ int main(int argc, char *argv[])
     int c_code_mode = 0;
     int escaped_match = 0;
     int do_newline = 0;
+    int want_format = 0; // This can be changed if the rendering function uses
+                         // formatting and would need double % to work
     // TODO: Generate line control preprocessor directives
     // - GCC: https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html
     // - MSVC: https://learn.microsoft.com/en-us/cpp/preprocessor/hash-line-directive-c-cpp
@@ -54,7 +56,7 @@ int main(int argc, char *argv[])
         } else { // We make sure to properly print the token
             String_Builder sb = {0};
             sb_append_buf(&sb, token.data, token.count-1);
-            if (c_code_mode) {
+            if (c_code_mode || !want_format) {
                 sb_append_cstr(&sb, "%");
             } else {
                 sb_append_cstr(&sb, "%%");

--- a/src_build/tt.c
+++ b/src_build/tt.c
@@ -23,18 +23,30 @@ void compile_byte_array(String_View s, int newline) {
 int main(int argc, char *argv[])
 {
     if (argc < 2) {
-        fprintf(stderr, "Usage: ./tt <template.h.tt>\n");
+        fprintf(stderr, "Usage: ./tt [--format] <template.h.tt>\n");
         return 1;
     }
-    const char *filepath = argv[1];
+    int want_format = 0; // This can be changed if the rendering function uses
+                         // formatting and would need double % to work
+    if (argc == 2) {
+        if (strcmp("--format", argv[1]) == 0) {
+            fprintf(stderr, "Missing file argument\n");
+            fprintf(stderr, "Usage: ./tt [--format] <template.h.tt>\n");
+            return 1;
+        }
+    } else {
+        if (strcmp("--format", argv[1]) == 0) {
+            want_format = 1;
+        }
+    }
+
+    const char *filepath = (want_format ? argv[2] : argv[1]);
     String_Builder sb = {0};
     if (!nob_read_entire_file(filepath, &sb)) return 1;
     String_View temp = sb_to_sv(sb);
     int c_code_mode = 0;
     int escaped_match = 0;
     int do_newline = 0;
-    int want_format = 0; // This can be changed if the rendering function uses
-                         // formatting and would need double % to work
     // TODO: Generate line control preprocessor directives
     // - GCC: https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html
     // - MSVC: https://learn.microsoft.com/en-us/cpp/preprocessor/hash-line-directive-c-cpp


### PR DESCRIPTION
This should enable any `\%` to be treated as a literal `%` with respect to the current mode, both for C code and for template text.

I don't know if this is a good idea.

I'm wondering both:
- if it's needed (one could use existing html replacements for `%` for the template text, and I guess avoid the operator for C code)
- if it accounts for some edge case.
I hope there's no big apparent issue with this.

Edit:
Since I figured there would be a need to know wether the "render" function expects formatting or not, I added an additional check to disable the usage of `%%`. This sounds kinda dumb. I think it would only be needed in templating mode, but maybe this is a sign of something being off. Maybe this is never needed.

Sample input:

```txt
<head>
% int x = 420; %
<title>69\% out of %INT(x)%</title>
%printf("\%s, \%d\n", "foo", x \% 5);%
%%bye
</head>
```

Sample output:

```txt
OUT("\x3c\x68\x65\x61\x64\x3e\x0a", 7);
 int x = 420; 
OUT("\x0a\x3c\x74\x69\x74\x6c\x65\x3e\x36\x39\x25\x25", 12);OUT("\x20\x6f\x75\x74\x20\x6f\x66\x20", 8);
INT(x)
OUT("\x3c\x2f\x74\x69\x74\x6c\x65\x3e\x0a", 9);
printf("%s, %d\n", "foo", x % 5);
OUT("\x0a", 1);

OUT("\x62\x79\x65\x0a\x3c\x2f\x68\x65\x61\x64\x3e\x0a", 12);
```

Sample usage:

*Edit: since the "rendering" is done through function expecting formatting, this would require setting the optional formatting when running `tt` at gentime.*
```c
void render_txt(void)
{
#define OUT(buf, size) fprintf(stdout, buf)
// TODO: ESCAPED_OUT does not actually escape anything
#define ESCAPED_OUT OUT
#define INT(x) fprintf(stdout, "%d", (x));
// TODO: the name of the compiled template is too vague and is not immediately apparent what it is
#include "template.h"
#undef OUT
#undef ESCAPED_OUT
#undef INT
}
```

```console
<head>

<title>69% out of 420</title>
foo, 0

bye
</head>
```

Also a sample usage with renders into a `String_Builder`, with differences:

- There's some usage of `sprintf()` which may not be liked
- The call to `printf()` done in the templated C code block ends up outside of the rendered text.
  - A nice idea could be to add some `TT_SB` macro to pass the `String_Builder` into C code.
    - Something like
      ```c
      void render_to_sb(Nob_String_Builder *sb)
      {
      #define TT_SB sb
        [...]
      #undef TT_SB
        [...]
      }
      ```
  - `String_Builder` contents at the end produces this (missing the `foo, 0` line which still ends up on stdout):
  ```console
  <head>

  <title>69%% out of 420</title>

  bye
  </head>
  ```
  - Note the double `%` in the in-memory contents, so that they may be printed as expected when using a print format function. (*Edit: this now requires setting the optional formatting check to work. I set it off by default.*)

```c
void render_to_sb(Nob_String_Builder *sb)
{
    char buff[256];
#define OUT(buf, size) nob_sb_append_buf(sb, buf, size)
// TODO: ESCAPED_OUT does not actually escape anything
#define ESCAPED_OUT OUT
#define INT(x) do { \
    sprintf(buf, "%d", x); \
    nob_sb_append_cstr(sb, buff); \
} while (0);\
// TODO: the name of the compiled template is too vague and is not immediately apparent what it is
#include "template.h"
#undef OUT
#undef ESCAPED_OUT
#undef INT
}
```