### PR TITLE
Implement `#line` for `tt`.

### DIFF
--- a/src_build/tt.c
+++ b/src_build/tt.c
@@ -8,11 +8,28 @@
 #define NOB_STRIP_PREFIX
 #include "nob.h"
 
-void compile_c_code(String_View s) {
+typedef struct {
+    int linenum;
+    const char *filename;
+} Line_Directive;
+
+void update_linenum(String_View s, Line_Directive *ld) {
+    for (uint64_t i = 0; i < s.count; ++i) {
+        if (s.data[i] == '\n') {
+            ++ld->linenum;
+        }
+    }
+}
+
+void compile_c_code(String_View s, Line_Directive *ld) {
+    printf("#line %d \"%s\"\n", ld->linenum, ld->filename);
+    update_linenum(s, ld);
     printf("%.*s\n", (int) s.count, s.data);
 }
 
-void compile_byte_array(String_View s) {
+void compile_byte_array(String_View s, Line_Directive *ld) {
+    printf("#line %d \"%s\"\n", ld->linenum, ld->filename);
+    update_linenum(s, ld);
     printf("OUT(\"");
     for (uint64_t i = 0; i < s.count; ++i) {
         printf("\\x%02x", s.data[i]);
@@ -30,16 +47,18 @@ int main(int argc, char *argv[])
     String_Builder sb = {0};
     if (!nob_read_entire_file(filepath, &sb)) return 1;
     String_View temp = sb_to_sv(sb);
+    Line_Directive ld = (Line_Directive) {
+        .linenum = 1,
+        .filename = filepath
+    };
+
     int c_code_mode = 0;
-    // TODO: Generate line control preprocessor directives
-    // - GCC: https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html
-    // - MSVC: https://learn.microsoft.com/en-us/cpp/preprocessor/hash-line-directive-c-cpp
     while (temp.count) {
         String_View token = sv_chop_by_delim(&temp, '%');
         if (c_code_mode) {
-            compile_c_code(token);
+            compile_c_code(token, &ld);
         } else {
-            compile_byte_array(token);
+            compile_byte_array(token, &ld);
         }
         c_code_mode = !c_code_mode;
     }


### PR DESCRIPTION
This patch adds line control directive for the generated template.

GCC: https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html
MSVC: https://learn.microsoft.com/en-us/cpp/preprocessor/hash-line-directive-c-cpp